### PR TITLE
refactor/ Se cambio a nombre completo los gets de las tablas intermedias

### DIFF
--- a/Services/Mappers/Mapping Administrative/AdministrativeMappingProfile.cs
+++ b/Services/Mappers/Mapping Administrative/AdministrativeMappingProfile.cs
@@ -302,7 +302,7 @@ public class AdministrativeMappingProfile : Profile
 
 
         CreateMap<ResidentMedication, ResidentMedicationGetDto>()
-            .ForMember(dest => dest.ResidentName, opt => opt.MapFrom(src => src.Resident.Name_RD))
+             .ForMember(dest => dest.ResidentFullName, opt => opt.MapFrom(src => $"{src.Resident.Name_RD} {src.Resident.Lastname1_RD} {src.Resident.Lastname2_RD}"))
             .ForMember(dest => dest.Name_MedicamentSpecific, opt => opt.MapFrom(src => src.MedicationSpecific.Name_MedicamentSpecific))
             .ForMember(dest => dest.UnitOfMeasureName, opt => opt.MapFrom(src => src.MedicationSpecific.UnitOfMeasure.UnitName));
 
@@ -315,7 +315,7 @@ public class AdministrativeMappingProfile : Profile
         CreateMap<ResidentPathology, ResidentPathologyGetDto>()
             .ForMember(dest => dest.DiagnosisDate, opt => opt.MapFrom(src => src.DiagnosisDate.ToString("yyyy-MM-dd")))
             .ForMember(dest => dest.RegisterDate, opt => opt.MapFrom(src => src.RegisterDate.ToString("yyyy-MM-dd")))
-            .ForMember(dest => dest.ResidentName, opt => opt.MapFrom(src => src.Resident.Name_RD))
+            .ForMember(dest => dest.ResidentFullName, opt => opt.MapFrom(src => $"{src.Resident.Name_RD} {src.Resident.Lastname1_RD} {src.Resident.Lastname2_RD}"))
             .ForMember(dest => dest.Name_Pathology, opt => opt.MapFrom(src => src.Pathology.Name_Pathology));
 
         CreateMap<ResidentPathologyCreateDto, ResidentPathology>()

--- a/Services/Services/Administrative/AdministrativeDTO/AdministrativeDTOGet/ResidentMedicationGetDto.cs
+++ b/Services/Services/Administrative/AdministrativeDTO/AdministrativeDTOGet/ResidentMedicationGetDto.cs
@@ -22,7 +22,7 @@ namespace Infrastructure.Services.Administrative.AdministrativeDTO.Administrativ
 
         // Relaciones
         public int Id_Resident { get; set; }
-        public string ResidentName { get; set; } // Ejemplo
+        public string ResidentFullName { get; set; } // Ejemplo
 
         public int Id_MedicamentSpecific { get; set; }
         public string Name_MedicamentSpecific { get; set; } // Ejemplo

--- a/Services/Services/Administrative/AdministrativeDTO/AdministrativeDTOGet/ResidentPathologyGetDto.cs
+++ b/Services/Services/Administrative/AdministrativeDTO/AdministrativeDTOGet/ResidentPathologyGetDto.cs
@@ -24,7 +24,7 @@ namespace Infrastructure.Services.Administrative.AdministrativeDTO.Administrativ
 
         // Relaciones
         public int Id_Resident { get; set; }
-        public string ResidentName { get; set; }
+        public string ResidentFullName { get; set; }
 
         public int Id_Pathology { get; set; }
         public string Name_Pathology { get; set; }

--- a/Services/Services/Administrative/EmployeeService/SvEmployee.cs
+++ b/Services/Services/Administrative/EmployeeService/SvEmployee.cs
@@ -76,7 +76,6 @@ namespace Infrastructure.Services.Administrative.AdministrativeDTO.EmployeeServi
             return (_mapper.Map<IEnumerable<EmployeeGetDTO>>(employees), totalPages);
         }
 
-        // Obtener empleados con profesiones específicas
         public async Task<IEnumerable<EmployeeByProfessionDTO>> GetEmployeesByProfessionsAsync(IEnumerable<int> professionIds)
         {
             var employees = await _employeeRepository.Query()


### PR DESCRIPTION
Refactorización de mapeos y eliminación de método obsoleto

Se ha modificado el mapeo de `ResidentMedication` y `ResidentPathology` a sus respectivos DTOs en la clase `AdministrativeMappingProfile`. Se ha reemplazado la propiedad `ResidentName` por `ResidentFullName`, que ahora concatena el nombre y los apellidos del residente.

En los archivos `ResidentMedicationGetDto.cs` y `ResidentPathologyGetDto.cs`, se ha realizado el mismo cambio de propiedad.

Se ha eliminado el método `GetEmployeesByProfessionsAsync` del archivo `SvEmployee.cs`.