### PR TITLE
feat/

### DIFF
--- a/Services/Services/Administrative/Residents/SvResident.cs
+++ b/Services/Services/Administrative/Residents/SvResident.cs
@@ -89,16 +89,21 @@ namespace Infrastructure.Services.Administrative.Residents
                 .Include(r => r.Appointments)
                     .ThenInclude(a => a.HealthcareCenter)
                 .Include(r => r.Appointments)
-                    .ThenInclude(a => a.Companion) 
+                    .ThenInclude(a => a.Companion)
                 .AsNoTracking()
                 .FirstOrDefaultAsync(r => r.Id_Resident == id);
 
             if (resident == null)
                 throw new KeyNotFoundException($"Resident with ID {id} not found.");
 
+            var currentYear = DateTime.Now.Year;
+            resident.Appointments = resident
+                .Appointments
+                .Where(a => a.Date.Year == currentYear)
+                .ToList();
+
             return _mapper.Map<ResidentMinimalInfoDto>(resident);
         }
-
 
         // Método para obtener un residente por ID
         public async Task<ResidentGetDto> GetResidentByIdAsync(int id)


### PR DESCRIPTION
Mejorar consulta de residentes y filtrar citas actuales

Se ha añadido la inclusión de la relación `Companion` en las citas de los residentes. Se eliminó una línea redundante y se implementó un filtro para que solo se incluyan las citas del año actual. Finalmente, se mapea el objeto `resident` a un DTO (`ResidentMinimalInfoDto`) antes de devolverlo.